### PR TITLE
LPP-53520 Install specific versions of curl and bash with other dependencies

### DIFF
--- a/templates/base/Dockerfile
+++ b/templates/base/Dockerfile
@@ -3,9 +3,34 @@ FROM --platform=${TARGETPLATFORM} ubuntu:jammy AS ubuntu-jammy
 COPY resources/etc/created-date /etc/created-date
 
 RUN apt-get update && \
-	DEBIAN_FRONTEND=noninteractive TZ=Etc/UTC apt-get install --no-install-recommends --yes bash ca-certificates curl jq less libnss3 telnet tini tree unzip && \
+	DEBIAN_FRONTEND=noninteractive TZ=Etc/UTC apt-get install --no-install-recommends --yes build-essential ca-certificates curl jq less libnghttp2-dev libnss3 libssl-dev nghttp2 telnet tini tree unzip && \
 	apt-get upgrade --yes && \
 	apt-get clean
+
+	RUN VERSION=8.7.1 && \
+	curl https://curl.se/download/curl-${VERSION}.tar.gz --output curl-${VERSION}.tar.gz && \
+	tar -xzvf curl-${VERSION}.tar.gz && \
+	rm -f curl-${VERSION}.tar.gz && \
+	cd curl-${VERSION} && \
+	apt-get remove curl -y && \
+	rm -rf /usr/bin/curl* && \
+	./configure --prefix=/usr/local --with-ssl --with-nghttp2 --enable-static && \
+	make -j4 && \
+	make install && \
+	ldconfig && \
+	cd .. && \
+	rm -rf curl-${VERSION}
+
+RUN VERSION=5.2 && \
+	curl https://ftp.gnu.org/gnu/bash/bash-${VERSION}.tar.gz --output bash-${VERSION}.tar.gz && \
+	tar -xzvf bash-${VERSION}.tar.gz && \
+	rm -f bash-${VERSION}.tar.gz && \
+	cd bash-${VERSION} && \
+	./configure --prefix=/usr && \
+	make -j4 && \
+	make install && \
+	cd .. && \
+	rm -rf bash-${VERSION}
 
 RUN adduser --disabled-password --home /home/liferay liferay --uid 1000 && \
 	addgroup liferay liferay && \


### PR DESCRIPTION
Hi @natocesarrego this way we can choose a version for curl and bash from outside the package manager. Some versions are can't be installed due to errors so it's safer to manually pick one.