### PR TITLE
LPD-28712 Modify the generation of releases.json so it can add only the new versions or regenerate from scratch

### DIFF
--- a/release/rebuild_releases_json.sh
+++ b/release/rebuild_releases_json.sh
@@ -13,6 +13,6 @@ mkdir -p "${_PROMOTION_DIR}"
 
 lc_cd "${_PROMOTION_DIR}"
 
-regenerate_releases_json
+generate_releases_json regenerate
 
 upload_releases_json

--- a/release/release_gold.sh
+++ b/release/release_gold.sh
@@ -92,7 +92,7 @@ function main {
 		lc_time_run upload_product_info_json
 	fi
 
-	lc_time_run regenerate_releases_json
+	lc_time_run generate_releases_json
 
 	lc_time_run upload_releases_json
 }


### PR DESCRIPTION
The new function I made _process_new_product is copied from _process_product. There are some lines that are the same but the two method needs to be invoked separately so rebuild_releases_json.sh can rebuild it and release_gold.sh can add the new versions to the existing file.
Is this structure ok or would it be better if I break down process_new_product and _process_product into 3 functions so it will be less code repeat?