### PR TITLE
LRP-4900 | master

### DIFF
--- a/release/build_release.sh
+++ b/release/build_release.sh
@@ -161,6 +161,8 @@ function main {
 
 		lc_time_run add_portal_patcher_properties_jar
 
+		lc_time_run add_portal_patcher_service_properties_jar
+
 		lc_time_run create_hotfix
 
 		lc_time_run calculate_checksums


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LRP-4900

/cc @laszlobereczki

The new hotfix builder already works for the new breaking changes introduced to 7.3 starting in U36.

However, by default 7.3 U36 and above hotfixes built with this new builder will fail patch level verification (basically comparing portal-impl and portal-kernel) which in turn causes a bundle start up failure.

The changes in this pull fix the patch level verification issue for 7.3 U36 and above hotfixes.

⚠️  These changes depend on https://github.com/pyoo47/liferay-jenkins-ee/pull/3253 and vice versa.